### PR TITLE
Fix AXIS DAC IP timing for DAC latching

### DIFF
--- a/cores/axis_red_pitaya_dac.v
+++ b/cores/axis_red_pitaya_dac.v
@@ -28,6 +28,7 @@ module axis_red_pitaya_dac #
 
   reg [DAC_DATA_WIDTH-1:0] int_dat_a_reg;
   reg [DAC_DATA_WIDTH-1:0] int_dat_b_reg;
+  reg int_rst_reg_dly;
   reg int_rst_reg;
 
   wire [DAC_DATA_WIDTH-1:0] int_dat_a_wire;
@@ -50,7 +51,8 @@ module axis_red_pitaya_dac #
       int_dat_a_reg <= {int_dat_a_wire[DAC_DATA_WIDTH-1], ~int_dat_a_wire[DAC_DATA_WIDTH-2:0]};
       int_dat_b_reg <= {int_dat_b_wire[DAC_DATA_WIDTH-1], ~int_dat_b_wire[DAC_DATA_WIDTH-2:0]};
     end
-    int_rst_reg <= ~locked | ~s_axis_tvalid;
+    int_rst_reg_dly <= ~locked | ~s_axis_tvalid;
+    int_rst_reg <= int_rst_reg_dly;
   end
 
   ODDR #(


### PR DESCRIPTION
Hi Pavel,
While using your wonderful project as a base for my custom development, I encountered a problem with the AXIS DAC IP.
I couldn't get it to latch a single data transfer (1 clock tvalid). Turns out dac_rst had to be delayed to let the IP clock out the data and then instruct the AD9767 DAC to latch it (see attached image from the datasheet). Without delay, the DAC would latch the 'b0 frame which is clocked out whenever tvalid is not present.

![image](https://github.com/traavnik/red-pitaya-notes/assets/20891943/99b0800a-0816-446d-b2c2-200a853d64d4)

The DAC is perfectly happy keeping the value latched indefinitely.

I've tested the IP with a sparse stream on a RedPitaya board. I expect no significant change to continuous streams apart from skipping erroneous 'b0 sample "injection" at the start of the stream.

Please consider checking this PR. Thanks!